### PR TITLE
Update `legitatx/topbarplus@3.0.5` to `1foreverhd/topbarplus@3.2.4`

### DIFF
--- a/wally.lock
+++ b/wally.lock
@@ -3,8 +3,8 @@
 registry = "test"
 
 [[package]]
-name = "legitatx/topbarplus"
-version = "3.0.5"
+name = "1foreverhd/topbarplus"
+version = "3.2.4"
 dependencies = []
 
 [[package]]
@@ -15,4 +15,4 @@ dependencies = []
 [[package]]
 name = "ryanlua/satchel"
 version = "1.3.1"
-dependencies = [["topbarplus", "legitatx/topbarplus@3.0.5"], ["testez", "roblox/testez@0.4.1"]]
+dependencies = [["topbarplus", "1foreverhd/topbarplus@3.2.4"], ["testez", "roblox/testez@0.4.1"]]

--- a/wally.toml
+++ b/wally.toml
@@ -10,7 +10,7 @@ exclude = ["**"]
 include = ["src", "src/*", "default.project.json", "wally.lock", "wally.toml"]
 
 [dependencies]
-topbarplus = "legitatx/topbarplus@3.0.5"
+topbarplus = "1foreverhd/topbarplus@3.2.4"
 
 [dev-dependencies]
 testez = "roblox/testez@0.4.1"


### PR DESCRIPTION
Updates the TopbarPlus package from using `legitatx/topbarplus@3.0.5` to `1foreverhd/topbarplus@3.2.4`. `legitatx/topbarplus` was used due to the bug with `1foreverhd/topbarplus` which has now been fixed.

Notable changes are that the topbar colors are properly matched.