### PR TITLE
fix: dead documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ Satchel fully supports all platforms which includes computer, tablet, phone, con
 ## 📖 Documentation
 
 > [!NOTE]
-> Visit the [Satchel documentation website](https://ryanluu.dev/Satchel) to learn about Satchel.
+> Visit the [Satchel documentation website](https://satchel.ryanluu.dev) to learn about Satchel.
 
-Satchel has it's very own [documentation site](https://ryanluu.dev/Satchel) you can visit. Find guides on how to get started and documentation.
+Satchel has it's very own [documentation site](https://satchel.ryanluu.dev) you can visit. Find guides on how to get started and documentation.
 
 <details>
 


### PR DESCRIPTION
## Description

Fixed a dead link in the README that was supposed to point to the documentation site.

## Changes Made

* Updated the documentation link in the README to the correct URL.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.