### PR TITLE
Use pcall in OnIconChanged for proper error handling

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -1481,14 +1481,14 @@ end
 
 local function OnIconChanged(enabled: boolean): ()
 	-- Check for enabling/disabling the whole thing
-	local success, topbarEnabled = pcall(function()
+	local success, _topbarEnabled = pcall(function()
 		return enabled and StarterGui:GetCore("TopbarEnabled")
 	end)
 
 	if not success then
 		return
 	end
-	
+
 	WholeThingEnabled = enabled
 	MainFrame.Visible = enabled
 


### PR DESCRIPTION
Rather than using `task.wait()` this should be wrapped in a pcall to prevent filling the console with errors. It's not guaranteed to exist even after 1 frame.

By the way, this current `task.wait()` "fix" isn't implemented in the current wally release at least, I would appreciate if you could merge this PR or at least have another wally release since that's better than nothing